### PR TITLE
Add a template for inspect predictions

### DIFF
--- a/notebooks/exploratory/inspect_predictions.ipynb
+++ b/notebooks/exploratory/inspect_predictions.ipynb
@@ -1,0 +1,388 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Inspecting normalizations"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note: This notebook should only be used to generate predictions on git branches created from a dvc experiment. On the main/dev branch this notebook will only be updated when changes to the code are necessary, but it will not be used to generate predictions there."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare data and get normalizations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import random\n",
+    "import tomli\n",
+    "\n",
+    "import datasets\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import torch\n",
+    "import transformers\n",
+    "from transnormer.models.train_model import tokenize_datasets\n",
+    "from transnormer.evaluation.analysis import get_spans_of_unknown_tokens\n",
+    "from transnormer.visualization.formatting import markup_spans"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Number of examples to generate predictions for\n",
+    "N = 20"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load configs\n",
+    "ROOT = \"../../\"\n",
+    "CONFIGFILE = os.path.join(ROOT, \"training_config.toml\")\n",
+    "with open(CONFIGFILE, mode=\"rb\") as fp:\n",
+    "    CONFIGS = tomli.load(fp)\n",
+    "\n",
+    "# OR: Use custom configs (if so: uncomment the following)\n",
+    "# CONFIGS = {\n",
+    "#     \"gpu\": \"cuda:0\",\n",
+    "#     \"random_seed\": 42,\n",
+    "#     \"tokenizer\": {\n",
+    "#         \"max_length_input\": 128,\n",
+    "#         \"max_length_output\": 128,\n",
+    "#         \"input_transliterator\": \"Transliterator1\",\n",
+    "#     },\n",
+    "#     \"language_models\": {\n",
+    "#         \"checkpoint_encoder\": \"prajjwal1/bert-tiny\",\n",
+    "#         \"checkpoint_decoder\": \"prajjwal1/bert-tiny\",\n",
+    "#     },\n",
+    "#     \"beam_search_decoding\": {\n",
+    "#         \"no_repeat_ngram_size\": 3,\n",
+    "#         \"early_stopping\": True,\n",
+    "#         \"length_penalty\": 2.0,\n",
+    "#         \"num_beams\": 4,\n",
+    "#     },\n",
+    "# }"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Fix seeds for reproducibilty\n",
+    "random.seed(CONFIGS[\"random_seed\"])\n",
+    "np.random.seed(CONFIGS[\"random_seed\"])\n",
+    "torch.manual_seed(CONFIGS[\"random_seed\"])\n",
+    "\n",
+    "# GPU set-up\n",
+    "device = torch.device(CONFIGS[\"gpu\"] if torch.cuda.is_available() else \"cpu\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load data \n",
+    "data_files = {\n",
+    "    \"1600to1699\": os.path.join(ROOT, \"data/interim/dtak-1600-1699/dtak-1600-1699-validation.jsonl\"),\n",
+    "    \"1700to1799\": os.path.join(ROOT, \"data/interim/dtak-1700-1799/dtak-1700-1799-validation.jsonl\"),\n",
+    "    \"1800to1899\": os.path.join(ROOT, \"data/interim/dtak-1800-1899/dtak-1800-1899-validation.jsonl\"),\n",
+    "}\n",
+    "ds = datasets.load_dataset(\"json\", data_files=data_files)\n",
+    "\n",
+    "ds[\"1600to1699\"] = ds[\"1600to1699\"].shuffle().select(range(N))\n",
+    "ds[\"1700to1799\"] = ds[\"1700to1799\"].shuffle().select(range(N))\n",
+    "ds[\"1800to1899\"] = ds[\"1800to1899\"].shuffle().select(range(N))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Tokenize data \n",
+    "\n",
+    "# In case we use locally saved models for the tokenizers\n",
+    "# the relative path must be completed. Uncomment the respective line.\n",
+    "# CONFIGS[\"language_models\"][\"checkpoint_encoder\"] = os.path.join(ROOT, CONFIGS[\"language_models\"][\"checkpoint_encoder\"])\n",
+    "# CONFIGS[\"language_models\"][\"checkpoint_decoder\"] = os.path.join(ROOT, CONFIGS[\"language_models\"][\"checkpoint_decoder\"])\n",
+    "\n",
+    "prepared_dataset, tokenizer_input, tokenizer_output = tokenize_datasets(ds, CONFIGS)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load model\n",
+    "checkpoint = os.path.join(ROOT, \"models/model/model_final\") # TODO\n",
+    "model = transformers.EncoderDecoderModel.from_pretrained(checkpoint).to(device)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Generate normalizations\n",
+    "# TODO: Do we have to include a configuration for beam search decoding here?\n",
+    "def generate_normalization(batch):\n",
+    "    inputs = tokenizer_input(batch[\"orig\"], padding=\"max_length\", truncation=True, max_length=128, return_tensors=\"pt\")\n",
+    "    input_ids = inputs.input_ids.to(device)\n",
+    "    attention_mask = inputs.attention_mask.to(device)\n",
+    "\n",
+    "    outputs = model.generate(input_ids, attention_mask=attention_mask)\n",
+    "    output_str = tokenizer_output.batch_decode(outputs, skip_special_tokens=True)\n",
+    "\n",
+    "    batch[\"norm_pred_str\"] = output_str\n",
+    "\n",
+    "    return batch\n",
+    "\n",
+    "\n",
+    "ds = ds.map(\n",
+    "    generate_normalization, \n",
+    "    batched=True, \n",
+    "    batch_size=8, \n",
+    "    load_from_cache_file=False,\n",
+    "    )\n"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Apply visual modifications \n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "1. Markup unknown tokens in red\n",
+    "2. Add token-separator (\"|\") in input text\n",
+    "2. Add token-separator (\"|\") in output text"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Apply HTML markup to unknown tokens in original text\n",
+    "def markup_unknown_tokens(batch):\n",
+    "    spans = get_spans_of_unknown_tokens(batch[\"orig\"], tokenizer_input)\n",
+    "    text_marked_up = markup_spans(batch[\"orig\"], spans, opening_tag=\"<span style='color:#FF0000'>\")\n",
+    "\n",
+    "    batch[\"orig_marked_up\"] = text_marked_up\n",
+    "    return batch\n",
+    "\n",
+    "ds = ds.map(markup_unknown_tokens, batched=False, )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Add token-separator \n",
+    "def separate_tokens(batch, column, tokenizer):\n",
+    "    # We have to do the normalization explicitly before getting the encoding\n",
+    "    # to avoid mismatches in case the normalization changes the string length, e.g. \"æ -> ae\"\n",
+    "    norm_str = tokenizer.backend_tokenizer.normalizer.normalize_str(batch[column])\n",
+    "    encoding = tokenizer(norm_str, add_special_tokens=False)\n",
+    "    spans = [\n",
+    "        # map a token index to a pair of character indices\n",
+    "        encoding.token_to_chars(token_index)[:] for token_index in range(len(encoding[\"input_ids\"]))\n",
+    "    ]\n",
+    "    text_marked_up = markup_spans(\n",
+    "        tokenizer.backend_tokenizer.normalizer.normalize_str(batch[column]),\n",
+    "        spans,\n",
+    "        opening_tag=\"\",\n",
+    "        closing_tag=\"<span style='color:#FFA500'>|</span>\",\n",
+    "        )\n",
+    "\n",
+    "    batch[f\"{column}_xlit_tok\"] = text_marked_up\n",
+    "    return batch\n",
+    "\n",
+    "ds = ds.map(separate_tokens, fn_kwargs={\"tokenizer\":tokenizer_input, \"column\" : \"orig\"}, batched=False, load_from_cache_file=False)\n",
+    "ds = ds.map(separate_tokens, fn_kwargs={\"tokenizer\":tokenizer_output, \"column\" : \"norm_pred_str\"}, batched=False, load_from_cache_file=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create pandas dataframes from predictions\n",
+    "\n",
+    "# Do no truncate cells with long text\n",
+    "pd.set_option('display.max_colwidth', None)\n",
+    "\n",
+    "part = \"1600to1699\"\n",
+    "df1600to1699 = pd.DataFrame(\n",
+    "    data={\n",
+    "        \"orig_xlit\" : ds[part][\"orig_xlit_tok\"], \n",
+    "        \"norm_tok\" : ds[part][\"norm_pred_str_xlit_tok\"], \n",
+    "        }\n",
+    "    )\n",
+    "\n",
+    "part = \"1700to1799\"\n",
+    "df1700to1799 = pd.DataFrame(\n",
+    "    data={\n",
+    "        \"orig_xlit\" : ds[part][\"orig_xlit_tok\"], \n",
+    "        \"norm_tok\" : ds[part][\"norm_pred_str_xlit_tok\"], \n",
+    "        }\n",
+    "    )\n",
+    "\n",
+    "part = \"1800to1899\"\n",
+    "df1800to1899 = pd.DataFrame(\n",
+    "    data={\n",
+    "        \"orig_xlit\" : ds[part][\"orig_xlit_tok\"], \n",
+    "        \"norm_tok\" : ds[part][\"norm_pred_str_xlit_tok\"], \n",
+    "        }\n",
+    "    )"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look at the dataframes"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1600 to 1699"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from IPython.core.display import HTML\n",
+    "display(HTML(df1600to1699.head(N).to_html(escape=False)))"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1700 to 1799"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from IPython.core.display import HTML\n",
+    "display(HTML(df1700to1799.head(N).to_html(escape=False)))"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1800 to 1899"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from IPython.core.display import HTML\n",
+    "display(HTML(df1800to1899.head(N).to_html(escape=False)))"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "gpu-venv-transnormer",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.16"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "78c4187baaf57098bb0b3703ce789bfcb46625a5d8666ee97b80d797f8c6f211"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
* Template notebook for inspection of predictions
* When an experiment branch is created, this notebook can be used to generate and analyze predictions. It should **not be used** directly on `dev`/`main`.
* Once the PR is closed and the described workflow has been successfully applied, the old inspection branch `dev-notebook-inspect-pred` can be deleted.