### PR TITLE
No longer set beam search decoding parameters during training

### DIFF
--- a/src/transnormer/models/train_model.py
+++ b/src/transnormer/models/train_model.py
@@ -176,14 +176,6 @@ def warmstart_seq2seq_model(
     model.config.eos_token_id = tokenizer.eos_token_id
     model.config.pad_token_id = tokenizer.pad_token_id
 
-    # Params for beam search decoding
-    model.config.no_repeat_ngram_size = configs["beam_search_decoding"][
-        "no_repeat_ngram_size"
-    ]
-    model.config.early_stopping = configs["beam_search_decoding"]["early_stopping"]
-    model.config.length_penalty = configs["beam_search_decoding"]["length_penalty"]
-    model.config.num_beams = configs["beam_search_decoding"]["num_beams"]
-
     return model
 
 

--- a/tests/test_train_model.py
+++ b/tests/test_train_model.py
@@ -278,20 +278,12 @@ def test_warmstart_seq2seq_model_single_encoder_decoder() -> None:
             "save_steps": 10,
             "fp16": False,
         },
-        "beam_search_decoding": {
-            "no_repeat_ngram_size": 3,
-            "early_stopping": True,
-            "length_penalty": 2.0,
-            "num_beams": 4,
-        },
     }
     device = torch.device(CONFIGS["gpu"] if torch.cuda.is_available() else "cpu")
     tokenizer = train_model.load_tokenizer(CONFIGS)
     model = train_model.warmstart_seq2seq_model(CONFIGS, tokenizer, device)
     # Check class
     assert isinstance(model, transformers.T5ForConditionalGeneration)
-    # Check some configs
-    assert model.config.num_beams == 4
 
 
 def test_data_collation() -> None:
@@ -333,12 +325,6 @@ def test_data_collation() -> None:
             "eval_strategy": "steps",
             "save_steps": 1,
             "fp16": False,  # set to False for byT5-based models
-        },
-        "beam_search_decoding": {
-            "no_repeat_ngram_size": 3,
-            "early_stopping": True,
-            "length_penalty": 2.0,
-            "num_beams": 4,
         },
     }
 
@@ -444,15 +430,9 @@ def test_train_seq2seq_model_single_encoder_decoder() -> None:
             "logging_steps": 1000,
             "eval_steps": 1000,
             "save_strategy": "epoch",
-            "eval_strategy": "steps",
-            "logging_strategy": "steps",
+            "eval_strategy": "epoch",
+            "logging_strategy": "epoch",
             "fp16": False,  # set to False for byT5-based models
-        },
-        "beam_search_decoding": {
-            "no_repeat_ngram_size": 3,
-            "early_stopping": True,
-            "length_penalty": 2.0,
-            "num_beams": 4,
         },
     }
     device = torch.device(CONFIGS["gpu"] if torch.cuda.is_available() else "cpu")

--- a/training_config.toml
+++ b/training_config.toml
@@ -45,6 +45,8 @@ n_examples_test = [
     # 1_000_000_000,
     # 1_000_000_000,
     ]
+# reverse_labels = false
+# do_shuffle = true
 
 [tokenizer]
 tokenizer = "google/byt5-small"
@@ -68,15 +70,3 @@ save_strategy = "epoch"
 eval_strategy = "epoch"
 logging_strategy = "epoch"
 # output_dir = "./models/models_2024-09-12"
-
-
-
-# Params for beam search decoding
-# see https://huggingface.co/blog/how-to-generate and https://huggingface.co/16transformers/v4.10.1/main_classes/model.html
-# These initial parameters were copied from
-# https://huggingface.co/blog/warm-starting-encoder-decoder#warm-starting-the-encoder-decoder-model
-[beam_search_decoding]
-no_repeat_ngram_size = 0
-early_stopping = true
-length_penalty = 2.0
-num_beams = 4


### PR DESCRIPTION
* Remove section in train_model.py where the pretrained model config for generation is set directly. Fixes warning about deprecated strategy to controll generation (see [here](https://github.com/huggingface/transformers/blob/c23d131eabcfa2cc722b483b2577ac6a0afc13ca/src/transformers/generation/utils.py#L1253-L1266))
* Remove same section from training_config.toml
* Update configs in tests/test_train_model.py
* Fixes #90